### PR TITLE
Added alter hooks for embed placeholder context and for the rendered embedded entity

### DIFF
--- a/lib/Drupal/entity_embed/Plugin/Filter/EntityEmbedFilter.php
+++ b/lib/Drupal/entity_embed/Plugin/Filter/EntityEmbedFilter.php
@@ -103,15 +103,15 @@ class EntityEmbedFilter extends FilterBase implements ContainerFactoryPluginInte
           if ($node->hasAttribute('data-entity-uuid')) {
             $uuid = $node->getAttribute('data-entity-uuid');
 
-            $entity_type_definition = $this->entity_manager->getDefinition($entity_type);
+            $entity_type_definition = $this->entityManager->getDefinition($entity_type);
             $uuid_key = $entity_type_definition->getKey('uuid');
-            $controller = $this->entity_manager->getStorage($entity_type);
+            $controller = $this->entityManager->getStorage($entity_type);
             $entity = reset($controller->loadByProperties(array($uuid_key => $uuid)));
           }
           elseif ($node->hasAttribute('data-entity-id')) {
             $id = $node->getAttribute('data-entity-id');
 
-            $controller = $this->entity_manager->getStorage($entity_type);
+            $controller = $this->entityManager->getStorage($entity_type);
             $entity = $controller->load($id);
 
             // Add the entity UUID attribute to the parent node.

--- a/lib/Drupal/entity_embed/Plugin/Filter/EntityEmbedFilter.php
+++ b/lib/Drupal/entity_embed/Plugin/Filter/EntityEmbedFilter.php
@@ -64,7 +64,7 @@ class EntityEmbedFilter extends FilterBase implements ContainerFactoryPluginInte
   public function __construct(array $configuration, $plugin_id, $plugin_definition, EntityManagerInterface $entity_manager, ModuleHandlerInterface $module_handler) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
     $this->entityManager = $entity_manager;
-    $this->moduleHanlder = $module_handler;
+    $this->moduleHandler = $module_handler;
   }
 
   /**


### PR DESCRIPTION
I realized other modules will probably want to add extra data attributes via the embed form, and have them affect entity display. Now that we're using post_render_cache we lose a bit of that context when doing the actual rendering. My proposal is for the following:
- Add all the attributes of the embed element into the post_render_cache token. So data-entity-type becomes `$context['entity-type']`.
- Add an alter hook for the $context array before it is converted into a placeholder.
- Add an alter hook or some kind of property to the entity before calling entity_view() to indicate that it is an embedded entity.
