### PR TITLE
Fix coding standard, no trailing punctuation after @see

### DIFF
--- a/lib/Drupal/entity_embed/Plugin/Filter/EntityEmbedFilter.php
+++ b/lib/Drupal/entity_embed/Plugin/Filter/EntityEmbedFilter.php
@@ -231,7 +231,7 @@ class EntityEmbedFilter extends FilterBase implements ContainerFactoryPluginInte
    * @return string
    *   The rendered entity HTML, or an empty string on failure.
    *
-   * @see \Drupal\entity_embed\Plugin\Filter\EntityEmbedFilter::buildPlaceholder().
+   * @see \Drupal\entity_embed\Plugin\Filter\EntityEmbedFilter::buildPlaceholder()
    */
   public static function renderEntityFromContext(array $context) {
     try {


### PR DESCRIPTION
Nitpick: Trailing punctuation for @see references is not allowed. Minor coding standard fix.
