### PR TITLE
Validate form for presence of required fields

### DIFF
--- a/src/Form/EntityEmbedCKEditorEmbedForm.php
+++ b/src/Form/EntityEmbedCKEditorEmbedForm.php
@@ -113,7 +113,7 @@ class EntityEmbedCKEditorEmbedForm extends FormBase {
       $status_messages = array('#theme' => 'status_messages');
       $output = drupal_render($form);
       $output = '<div>' . drupal_render($status_messages) . $output . '</div>';
-      $response->addCommand(new HtmlCommand('#entity-embed-ckeditor-select-form', $output));
+      $response->addCommand(new HtmlCommand('#entity-embed-ckeditor-embed-form', $output));
     }
     else {
       $response->addCommand(new EntityEmbedSubmitDialogSave($form_state['values']));

--- a/src/Form/EntityEmbedCKEditorEmbedForm.php
+++ b/src/Form/EntityEmbedCKEditorEmbedForm.php
@@ -56,6 +56,7 @@ class EntityEmbedCKEditorEmbedForm extends FormBase {
       '#name' => 'view_mode',
       '#title' => 'View Mode',
       '#options' => $view_modes,
+      '#required' => TRUE,
     );
     $form['display_links'] = array(
       '#type' => 'checkbox',

--- a/src/Form/EntityEmbedCKEditorEmbedForm.php
+++ b/src/Form/EntityEmbedCKEditorEmbedForm.php
@@ -107,8 +107,18 @@ class EntityEmbedCKEditorEmbedForm extends FormBase {
   public function submitForm(array &$form, array &$form_state) {
     $response = new AjaxResponse();
 
-    $response->addCommand(new EntityEmbedSubmitDialogSave($form_state['values']));
-    $response->addCommand(new CloseModalDialogCommand());
+    // Display errors in form, if any.
+    if (form_get_errors($form_state)) {
+      unset($form['#prefix'], $form['#suffix']);
+      $status_messages = array('#theme' => 'status_messages');
+      $output = drupal_render($form);
+      $output = '<div>' . drupal_render($status_messages) . $output . '</div>';
+      $response->addCommand(new HtmlCommand('#entity-embed-ckeditor-select-form', $output));
+    }
+    else {
+      $response->addCommand(new EntityEmbedSubmitDialogSave($form_state['values']));
+      $response->addCommand(new CloseModalDialogCommand());
+    }
 
     return $response;
   }

--- a/src/Form/EntityEmbedCKEditorEmbedForm.php
+++ b/src/Form/EntityEmbedCKEditorEmbedForm.php
@@ -127,7 +127,11 @@ class EntityEmbedCKEditorEmbedForm extends FormBase {
       $status_messages = array('#theme' => 'status_messages');
       $output = drupal_render($form);
       $output = '<div>' . drupal_render($status_messages) . $output . '</div>';
-      $response->addCommand(new HtmlCommand('#entity-embed-ckeditor-embed-form', $output));
+      # Using drupal_html_class() to obtain hypen separated form id. Using
+      # drupal_html_id() instead results in adding an unnecessary counter at the
+      # end of the string.
+      $form_id = '#' . drupal_html_class($form_state['values']['form_id']);
+      $response->addCommand(new HtmlCommand($form_id, $output));
     }
     else {
       $response->addCommand(new EntityEmbedSubmitDialogSave($form_state['values']));

--- a/src/Form/EntityEmbedCKEditorEmbedForm.php
+++ b/src/Form/EntityEmbedCKEditorEmbedForm.php
@@ -105,6 +105,19 @@ class EntityEmbedCKEditorEmbedForm extends FormBase {
   /**
    * {@inheritdoc}
    */
+  public function validateForm(array &$form, array &$form_state) {
+    $entity_type = $form_state['values']['entity_type'];
+    $entity = $form_state['values']['entity'];
+    if (empty($entity_type) || empty($entity)) {
+      $this->setFormError('', $form_state, $this->t('Required fields from previous step of the form are missing. Go back and try again.'));
+    }
+
+    parent::validateForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
   public function submitForm(array &$form, array &$form_state) {
     $response = new AjaxResponse();
 

--- a/src/Form/EntityEmbedCKEditorEmbedForm.php
+++ b/src/Form/EntityEmbedCKEditorEmbedForm.php
@@ -122,7 +122,7 @@ class EntityEmbedCKEditorEmbedForm extends FormBase {
     $response = new AjaxResponse();
 
     // Display errors in form, if any.
-    if (form_get_errors($form_state)) {
+    if (\Drupal::formBuilder()->getErrors($form_state)) {
       unset($form['#prefix'], $form['#suffix']);
       $status_messages = array('#theme' => 'status_messages');
       $output = drupal_render($form);

--- a/src/Form/EntityEmbedCKEditorEmbedForm.php
+++ b/src/Form/EntityEmbedCKEditorEmbedForm.php
@@ -22,7 +22,7 @@ class EntityEmbedCKEditorEmbedForm extends FormBase {
    * {@inheritdoc}
    */
   public function getFormId() {
-    return 'entity_embed_ckeditor_form';
+    return 'entity_embed_ckeditor_embed_form';
   }
 
   /**

--- a/src/Form/EntityEmbedCKEditorSelectForm.php
+++ b/src/Form/EntityEmbedCKEditorSelectForm.php
@@ -81,7 +81,11 @@ class EntityEmbedCKEditorSelectForm extends FormBase {
       $status_messages = array('#theme' => 'status_messages');
       $output = drupal_render($form);
       $output = '<div>' . drupal_render($status_messages) . $output . '</div>';
-      $response->addCommand(new HtmlCommand('#entity-embed-ckeditor-select-form', $output));
+      # Using drupal_html_class() to obtain hypen separated form id. Using
+      # drupal_html_id() instead results in adding an unnecessary counter at the
+      # end of the string.
+      $form_id = '#' . drupal_html_class($form_state['values']['form_id']);
+      $response->addCommand(new HtmlCommand($form_id, $output));
     }
     else {
       // Detect if a valid UUID was specified. Set embed method based based on

--- a/src/Form/EntityEmbedCKEditorSelectForm.php
+++ b/src/Form/EntityEmbedCKEditorSelectForm.php
@@ -76,7 +76,7 @@ class EntityEmbedCKEditorSelectForm extends FormBase {
     $response = new AjaxResponse();
 
     // Display errors in form, if any.
-    if (form_get_errors($form_state)) {
+    if (\Drupal::formBuilder()->getErrors($form_state)) {
       unset($form['#prefix'], $form['#suffix']);
       $status_messages = array('#theme' => 'status_messages');
       $output = drupal_render($form);

--- a/src/Form/EntityEmbedCKEditorSelectForm.php
+++ b/src/Form/EntityEmbedCKEditorSelectForm.php
@@ -23,7 +23,7 @@ class EntityEmbedCKEditorSelectForm extends FormBase {
    * {@inheritdoc}
    */
   public function getFormId() {
-    return 'entity_embed_ckeditor_form';
+    return 'entity_embed_ckeditor_select_form';
   }
 
   /**

--- a/src/Form/EntityEmbedCKEditorSelectForm.php
+++ b/src/Form/EntityEmbedCKEditorSelectForm.php
@@ -74,19 +74,29 @@ class EntityEmbedCKEditorSelectForm extends FormBase {
   public function submitForm(array &$form, array &$form_state) {
     $response = new AjaxResponse();
 
-    // Detect if a valid UUID was specified. Set embed method based based on
-    // whether or not it is a valid UUID.
-    $values = $form_state['values'];
-    $entity = $values['entity'];
-    if (Uuid::isValid($entity)) {
-      $values['embed_method'] = 'uuid';
+    // Display errors in form, if any.
+    if (form_get_errors($form_state)) {
+      unset($form['#prefix'], $form['#suffix']);
+      $status_messages = array('#theme' => 'status_messages');
+      $output = drupal_render($form);
+      $output = '<div>' . drupal_render($status_messages) . $output . '</div>';
+      $response->addCommand(new HtmlCommand('#entity-embed-ckeditor-select-form', $output));
     }
     else {
-      $values['embed_method'] = 'id';
-    }
+      // Detect if a valid UUID was specified. Set embed method based based on
+      // whether or not it is a valid UUID.
+      $values = $form_state['values'];
+      $entity = $values['entity'];
+      if (Uuid::isValid($entity)) {
+        $values['embed_method'] = 'uuid';
+      }
+      else {
+        $values['embed_method'] = 'id';
+      }
 
-    $response->addCommand(new EntityEmbedSelectDialogSave($values));
-    $response->addCommand(new CloseModalDialogCommand());
+      $response->addCommand(new EntityEmbedSelectDialogSave($values));
+      $response->addCommand(new CloseModalDialogCommand());
+    }
 
     return $response;
   }

--- a/src/Form/EntityEmbedCKEditorSelectForm.php
+++ b/src/Form/EntityEmbedCKEditorSelectForm.php
@@ -37,6 +37,7 @@ class EntityEmbedCKEditorSelectForm extends FormBase {
       '#name' => 'entity_type',
       '#title' => 'Entity type',
       '#options' => \Drupal::entityManager()->getEntityTypeLabels(TRUE),
+      '#required' => TRUE,
     );
     $form['entity'] = array(
       '#type' => 'textfield',


### PR DESCRIPTION
Make following fields compulsory: entity_type, entity and view mode.
If any error occurs, show the error in the dialog before proceeding further.

At the final step before submit happens, validate form to ensure all the required fields are present (from previous step as well as this step)

Validating presence of fields from previous step just to be sure, a conservative step.

d.o issue: https://drupal.org/node/2279175
