### PR TITLE
Added hook_entity_preembed().

### DIFF
--- a/entity_embed.api.php
+++ b/entity_embed.api.php
@@ -30,6 +30,22 @@ function hook_entity_embed_context_alter(array &$context, &$callback, \Drupal\Co
 }
 
 /**
+ * Act on an entity before it is about to be rendered in an embed.
+ *
+ * @param \Drupal\Core\Entity\EntityInterface $entity
+ *   The entity object.
+ * @param array $context
+ *   The context array.
+ */
+function hook_entity_preembed(\Drupal\Core\Entity\EntityInterface $entity, array $context) {
+  if (isset($context['overrides']) && is_array($context['overrides'])) {
+    foreach ($context['overrides'] as $key => $value) {
+      $entity->key = $value;
+    }
+  }
+}
+
+/**
  * Alter the result of \Drupal\entity_embed\EntityEmbedDisplayBase::build().
  *
  * This hook is called after the content has been assembled in a structured

--- a/src/Plugin/Filter/EntityEmbedFilter.php
+++ b/src/Plugin/Filter/EntityEmbedFilter.php
@@ -257,7 +257,7 @@ class EntityEmbedFilter extends FilterBase implements ContainerFactoryPluginInte
         // https://drupal.org/node/2247779 .
         // @see https://drupal.org/node/2281487 .
         // Allow modules to alter the entity prior to display rendering.
-        \Drupal::moduleHandler()->invokeAll('entity_preembed', $entity, $context);
+        \Drupal::moduleHandler()->invokeAll('entity_preembed', array($entity, $context));
         // Build the display plugin.
         $manager = \Drupal::service('plugin.manager.entity_embed.display');
         $display = $manager->createInstance($context['entity-embed-display'], $context['entity-embed-settings']);

--- a/src/Plugin/Filter/EntityEmbedFilter.php
+++ b/src/Plugin/Filter/EntityEmbedFilter.php
@@ -256,10 +256,15 @@ class EntityEmbedFilter extends FilterBase implements ContainerFactoryPluginInte
         // @todo, This direct usage can be replaced with injection following
         // https://drupal.org/node/2247779 .
         // @see https://drupal.org/node/2281487 .
+        // Allow modules to alter the entity prior to display rendering.
+        \Drupal::moduleHandler()->invokeAll('entity_preembed', $entity, $context);
+        // Build the display plugin.
         $manager = \Drupal::service('plugin.manager.entity_embed.display');
         $display = $manager->createInstance($context['entity-embed-display'], $context['entity-embed-settings']);
         $display->setContextValue('entity', $entity);
         $display->setAttributes($context);
+        // Check if the display plugin is accessible. This also checks entity
+        // access, which is why we never call $entity->access() here.
         if ($display->access()) {
           $build = $display->build();
           // Allow modules to alter the rendered embedded entity.


### PR DESCRIPTION
This will allow modules to alter the entity before it will be rendered. I was thinking about the use case we've had with the Media module that people want to override specfic fields on the entity when it is embedded in a specific place. Right now there's no way for that to happen since the entity is loaded fresh on embed and render.
