### PR TITLE
Removed code that toggles link display.

### DIFF
--- a/js/entity_embed.ajax.js
+++ b/js/entity_embed.ajax.js
@@ -82,11 +82,6 @@
         entityDiv.setAttribute('data-show-caption', 'data-show-caption');
       }
 
-      // Set display links attribute, only if its set in the form.
-      if(response.values.display_links == 1) {
-        entityDiv.setAttribute('data-display-links', 'data-display-links');
-      }
-
       // Set a placeholder.
       entityDiv.innerHTML = response.values.entity_type + ": " + response.values.entity;
 

--- a/src/EntityEmbedDisplay/EntityEmbedDefaultDisplay.php
+++ b/src/EntityEmbedDisplay/EntityEmbedDefaultDisplay.php
@@ -105,11 +105,6 @@ class EntityEmbedDefaultDisplay extends EntityEmbedDisplayBase implements Contai
     $render_controller = $this->entityManager->getViewBuilder($entity->getEntityTypeId());
     $build = $render_controller->view($entity, $view_mode, $langcode);
 
-    // Hide entity links by default.
-    if (isset($build['links'])) {
-      $build['links']['#access'] = FALSE;
-    }
-
     return $build;
   }
 }

--- a/src/Form/EntityEmbedCKEditorEmbedForm.php
+++ b/src/Form/EntityEmbedCKEditorEmbedForm.php
@@ -59,11 +59,6 @@ class EntityEmbedCKEditorEmbedForm extends FormBase {
       '#options' => $view_modes,
       '#required' => TRUE,
     );
-    $form['display_links'] = array(
-      '#type' => 'checkbox',
-      '#name' => 'display_links',
-      '#title' => $this->t('Display links'),
-    );
     $form['align'] = array(
       '#type' => 'select',
       '#name' => 'align',


### PR DESCRIPTION
This functionality is not actually supported and broken in core. If people still desire this functionality, they can use the EntityReferenceFieldFormatter display plugin while this option still exists in core.

The core issues for reference:
https://drupal.org/node/2274975
https://drupal.org/node/2271349
