### PR TITLE
Update EntityEmbedDisplayManager no longer needs LanguageManager.

### DIFF
--- a/entity_embed.services.yml
+++ b/entity_embed.services.yml
@@ -1,4 +1,4 @@
 services:
   plugin.manager.entity_embed.display:
     class: Drupal\entity_embed\EntityEmbedDisplay\EntityEmbedDisplayManager
-    arguments: ['@container.namespaces', '@cache.discovery', '@language_manager', '@module_handler', '@string_translation']
+    arguments: ['@container.namespaces', '@cache.discovery', '@module_handler']

--- a/src/EntityEmbedDisplay/EntityEmbedDisplayManager.php
+++ b/src/EntityEmbedDisplay/EntityEmbedDisplayManager.php
@@ -35,10 +35,10 @@ class EntityEmbedDisplayManager extends DefaultPluginManager {
    * @param \Drupal\Core\Extension\ModuleHandlerInterface $module_handler
    *   The module handler to invoke the alter hook with.
    */
-  public function __construct(\Traversable $namespaces, CacheBackendInterface $cache_backend, LanguageManager $language_manager, ModuleHandlerInterface $module_handler) {
+  public function __construct(\Traversable $namespaces, CacheBackendInterface $cache_backend, ModuleHandlerInterface $module_handler) {
     parent::__construct('EntityEmbedDisplay', $namespaces, $module_handler, 'Drupal\entity_embed\Annotation\EntityEmbedDisplay');
     $this->alterInfo('entity_embed_display_plugins');
-    $this->setCacheBackend($cache_backend, $language_manager, 'entity_embed_display_plugins');
+    $this->setCacheBackend($cache_backend, 'entity_embed_display_plugins');
   }
 
   /**


### PR DESCRIPTION
https://drupal.org/node/2281905 was committed to core, so we need to update our plugin manager since we extend the DefaultPluginManager from core.
