### PR TITLE
Fix coding standard

### DIFF
--- a/src/Plugin/Filter/EntityEmbedFilter.php
+++ b/src/Plugin/Filter/EntityEmbedFilter.php
@@ -22,7 +22,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  *
  * @Filter(
  *   id = "entity_embed",
- *   title = @Translation("Display embedded entities."),
+ *   title = @Translation("Display embedded entities"),
  *   description = @Translation("Embeds entities using data attributes: data-entity-type, data-entity-uuid or data-entity-id, and data-view-mode."),
  *   type = Drupal\filter\Plugin\FilterInterface::TYPE_TRANSFORM_REVERSIBLE
  * )


### PR DESCRIPTION
Nitpick: According to the standards core follows, there shouldn't be a full-stop preceding the filter name.
