### PR TITLE
Removed modification of data attribute keys.

### DIFF
--- a/src/EntityEmbedDisplay/EntityEmbedDefaultDisplay.php
+++ b/src/EntityEmbedDisplay/EntityEmbedDefaultDisplay.php
@@ -51,7 +51,7 @@ class EntityEmbedDefaultDisplay extends EntityEmbedDisplayBase {
     $form['view_mode'] = array(
       '#type' => 'select',
       '#title' => t('View mode'),
-      '#options' => $this->entityManager()->getViewModeOptions($this->getAttributeValue('entity-type')),
+      '#options' => $this->entityManager()->getViewModeOptions($this->getContextValue('entity')->getEntityTypeId()),
       '#default_value' => $this->getConfigurationValue('view_mode'),
       '#required' => TRUE,
     );
@@ -65,7 +65,7 @@ class EntityEmbedDefaultDisplay extends EntityEmbedDisplayBase {
   public function build() {
     $entity = $this->getContextValue('entity');
     $view_mode = $this->getConfigurationValue('view_mode');
-    $langcode = $this->getAttributeValue('langcode');
+    $langcode = $this->getAttributeValue('data-langcode');
     return $this->renderEntity($entity, $view_mode, $langcode);
   }
 }

--- a/src/EntityEmbedDisplay/FieldFormatterEntityEmbedDisplayBase.php
+++ b/src/EntityEmbedDisplay/FieldFormatterEntityEmbedDisplayBase.php
@@ -45,6 +45,7 @@ abstract class FieldFormatterEntityEmbedDisplayBase extends EntityEmbedDisplayBa
     // doesn't load in the field type defaults. https://drupal.org/node/2116341
     $definition = $this->getFieldDefinition();
     // Ensure that the field name is unique each time this is run.
+    // @todo This probably shouldn't rely on the render cache token attribute.
     $definition->setName('_entity_embed_' . $this->getAttributeValue('token'));
 
     /* @var \Drupal\Core\Field\FieldItemListInterface $items $items */
@@ -58,7 +59,7 @@ abstract class FieldFormatterEntityEmbedDisplayBase extends EntityEmbedDisplayBa
       $node
     );
 
-    if ($langcode = $this->getAttributeValue('langcode')) {
+    if ($langcode = $this->getAttributeValue('data-langcode')) {
       $items->setLangcode($langcode);
     }
 
@@ -102,6 +103,7 @@ abstract class FieldFormatterEntityEmbedDisplayBase extends EntityEmbedDisplayBa
     }
 
     // Ensure that the field name is unique each time this is run.
+    // @todo This probably shouldn't rely on the render cache token attribute.
     $definition->setName('_entity_embed_' . $this->getAttributeValue('token'));
 
     $display = array(

--- a/src/EntityEmbedPostRenderCache.php
+++ b/src/EntityEmbedPostRenderCache.php
@@ -71,12 +71,12 @@ class EntityEmbedPostRenderCache {
 
     $entity_output = '';
     try {
-      $id = $context['entity-uuid'] ?: $context['entity-id'];
-      if ($entity = $this->loadEntity($context['entity-type'], $id)) {
+      $id = $context['data-entity-uuid'] ?: $context['data-entity-id'];
+      if ($entity = $this->loadEntity($context['data-entity-type'], $id)) {
         $entity_output = $this->renderEntityEmbedDisplayPlugin(
           $entity,
-          $context['entity-embed-display'],
-          $context['entity-embed-settings'],
+          $context['data-entity-embed-display'],
+          $context['data-entity-embed-settings'],
           $context
         );
       }

--- a/src/Plugin/Filter/EntityEmbedFilter.php
+++ b/src/Plugin/Filter/EntityEmbedFilter.php
@@ -95,12 +95,12 @@ class EntityEmbedFilter extends FilterBase implements ContainerFactoryPluginInte
             // Set the initial langcode but it can be overridden by a data
             // attribute.
             if (!empty($langcode)) {
-              $context['langcode'] = $langcode;
+              $context['data-langcode'] = $langcode;
             }
 
             // Convert the data attributes to the context array.
             foreach ($node->attributes as $attribute) {
-              $key = strtr($attribute->nodeName, array('data-' => ''));
+              $key = $attribute->nodeName;
               $context[$key] = $attribute->nodeValue;
 
               // Check for JSON-encoded attributes.
@@ -111,9 +111,9 @@ class EntityEmbedFilter extends FilterBase implements ContainerFactoryPluginInte
             }
 
             // Support the deprecated view-mode data attribute.
-            if (isset($context['view-mode']) && !isset($context['entity-embed-display']) && !isset($context['entity-embed-settings'])) {
-              $context['entity-embed-settings']['view_mode'] = $context['view-mode'];
-              unset($context['view-mode']);
+            if (isset($context['data-view-mode']) && !isset($context['data-entity-embed-display']) && !isset($context['data-entity-embed-settings'])) {
+              $context['data-entity-embed-settings']['view_mode'] = $context['data-view-mode'];
+              unset($context['data-view-mode']);
             }
 
             $placeholder = $this->buildPlaceholder($entity, $result, $context);
@@ -167,11 +167,11 @@ class EntityEmbedFilter extends FilterBase implements ContainerFactoryPluginInte
   public function buildPlaceholder(EntityInterface $entity, FilterProcessResult $result, array $context = array()) {
     $callback = 'entity_embed.post_render_cache:renderEmbed';
     $context += array(
-      'entity-type' => $entity->getEntityTypeId(),
-      'entity-id' => $entity->id(),
-      'entity-embed-display' => 'default',
-      'entity-embed-settings' => array(),
-      'langcode' => NULL,
+      'data-entity-type' => $entity->getEntityTypeId(),
+      'data-entity-id' => $entity->id(),
+      'data-entity-embed-display' => 'default',
+      'data-entity-embed-settings' => array(),
+      'data-langcode' => NULL,
     );
 
     // Allow modules to alter the context.


### PR DESCRIPTION
Was starting to get frustrated about sometimes we have to use 'data-entity-type' and other times we use 'entity-type'. It would be better for us and for others to just be consistent and not remove the 'data-' prefix from the attributes.
