### PR TITLE
Rename name of the tests to remove trailing 'test' in getInfo()

### DIFF
--- a/src/Tests/EntityEmbedFilterTest.php
+++ b/src/Tests/EntityEmbedFilterTest.php
@@ -25,7 +25,7 @@ class EntityEmbedFilterTest extends WebTestBase {
 
   public static function getInfo() {
     return array(
-      'name' => 'Entity Embed Filter Test',
+      'name' => 'Entity Embed filter',
       'description' => 'Tests the entity_embed filter',
       'group' => 'Entity Embed',
     );

--- a/src/Tests/EntityEmbedPreviewTest.php
+++ b/src/Tests/EntityEmbedPreviewTest.php
@@ -25,7 +25,7 @@ class EntityEmbedPreviewTest extends WebTestBase {
 
   public static function getInfo() {
     return array(
-      'name' => 'Entity Embed Preview Test',
+      'name' => 'Preview of embedded entity',
       'description' => 'Tests the entity_embed controller and route',
       'group' => 'Entity Embed',
     );


### PR DESCRIPTION
Trying to follow the same standard as Core. No need for an extra 'test' at the end of the test names.
