### PR TITLE
Remove un-necessary assignment of drupalGet's result to $html

### DIFF
--- a/src/Tests/EntityEmbedFilterTest.php
+++ b/src/Tests/EntityEmbedFilterTest.php
@@ -25,7 +25,7 @@ class EntityEmbedFilterTest extends EntityEmbedTestBase {
     $settings['body'] = array(array('value' => $content));
     $node = $this->drupalCreateNode($settings);
 
-    $html = $this->drupalGet('node/' . $node->id());
+    $this->drupalGet('node/' . $node->id());
 
     $this->assertText($this->node->body->value, 'Embedded node exists in page');
     $this->assertNoText(strip_tags($content), 'Placeholder does not appears in the output when embed is successful.');
@@ -42,7 +42,7 @@ class EntityEmbedFilterTest extends EntityEmbedTestBase {
     $settings['body'] = array(array('value' => $content));
     $node = $this->drupalCreateNode($settings);
 
-    $html = $this->drupalGet('node/' . $node->id());
+    $this->drupalGet('node/' . $node->id());
 
     $this->assertText($this->node->body->value, 'Embedded node exists in page.');
     $this->assertNoText(strip_tags($content), 'Placeholder does not appears in the output when embed is successful.');
@@ -59,7 +59,7 @@ class EntityEmbedFilterTest extends EntityEmbedTestBase {
     $settings['body'] = array(array('value' => $content));
     $node = $this->drupalCreateNode($settings);
 
-    $html = $this->drupalGet('node/' . $node->id());
+    $this->drupalGet('node/' . $node->id());
 
     $this->assertText(strip_tags($content), 'Placeholder appears in the output when embed is unsuccessful.');
   }
@@ -77,7 +77,7 @@ class EntityEmbedFilterTest extends EntityEmbedTestBase {
     $settings['body'] = array(array('value' => $content));
     $node = $this->drupalCreateNode($settings);
 
-    $html = $this->drupalGet('node/' . $node->id());
+    $this->drupalGet('node/' . $node->id());
 
     $this->assertText($this->node->body->value, 'Entity specifed with UUID exists in the page.');
     $this->assertNoText($sample_node->body->value, 'Entity specifed with ID does not exists in the page.');
@@ -95,7 +95,7 @@ class EntityEmbedFilterTest extends EntityEmbedTestBase {
     $settings['body'] = array(array('value' => $content));
     $node = $this->drupalCreateNode($settings);
 
-    $html = $this->drupalGet('node/' . $node->id());
+    $this->drupalGet('node/' . $node->id());
 
     $this->assertText($this->node->body->value, 'Embedded node exists in page.');
     $this->assertNoText(strip_tags($content), 'Placeholder does not appears in the output when embed is successful.');
@@ -112,7 +112,7 @@ class EntityEmbedFilterTest extends EntityEmbedTestBase {
     $settings['body'] = array(array('value' => $content));
     $node = $this->drupalCreateNode($settings);
 
-    $html = $this->drupalGet('node/' . $node->id());
+    $this->drupalGet('node/' . $node->id());
 
     $this->assertText($this->node->body->value, 'Embedded node exists in page with the view mode specified by entity-embed-settings.');
     $this->assertNoText(strip_tags($content), 'Placeholder does not appears in the output when embed is successful.');

--- a/src/Tests/EntityEmbedPreviewTest.php
+++ b/src/Tests/EntityEmbedPreviewTest.php
@@ -27,7 +27,7 @@ class EntityEmbedPreviewTest extends EntityEmbedTestBase {
   public function testPreviewController() {
     $content = '<div data-entity-type="node" data-entity-id="' . $this->node->id() . '" data-view-mode="teaser">This placeholder should not be rendered.</div>';
 
-    $html = $this->drupalGet($this->preview_url, array('query' => array('value' => $content)));
+    $this->drupalGet($this->preview_url, array('query' => array('value' => $content)));
 
     $this->assertResponse(200, 'The preview route exists.');
     $this->assertText($this->node->body->value, 'Embedded node exists in page');
@@ -39,7 +39,7 @@ class EntityEmbedPreviewTest extends EntityEmbedTestBase {
    */
   public function testPreviewControllerInvalidRequest() {
     $content = 'Testing preview route without valid values';
-    $html = $this->drupalGet($this->preview_url, array('query' => array('value' => $content)));
+    $this->drupalGet($this->preview_url, array('query' => array('value' => $content)));
 
     $this->assertResponse(200, 'The preview route exists.');
     $this->assertText($content, 'Placeholder appears in the output when embed is unsuccessful.');
@@ -49,7 +49,7 @@ class EntityEmbedPreviewTest extends EntityEmbedTestBase {
    * Tests preview route with an empty request.
    */
   public function testPreviewControllerEmptyRequest() {
-    $html = $this->drupalGet($this->preview_url);
+    $this->drupalGet($this->preview_url);
 
     $this->assertResponse(404, "The preview returns 'Page not found' when GET parameters are not provided.");
   }


### PR DESCRIPTION
Result of `drupalget` is assigned to `$html` at several places, which is complete un-necessary. This issue aims to remove such instances.
