### PR TITLE
Move tests inside a single method and remove unused code

### DIFF
--- a/src/Tests/EntityEmbedFilterTest.php
+++ b/src/Tests/EntityEmbedFilterTest.php
@@ -15,105 +15,77 @@ namespace Drupal\entity_embed\Tests;
 class EntityEmbedFilterTest extends EntityEmbedTestBase {
 
   /**
-   * Tests entity embed using entity ID and view mode.
+   * Tests the entity_embed filter.
+   *
+   * Ensures that entities are getting rendered when correct data attributes
+   * are passed. Also tests situations when embed fails.
    */
-  public function testFilterIdViewMode() {
+  public function testFilter() {
+    // Tests entity embed using entity ID and view mode.
     $content = '<div data-entity-type="node" data-entity-id="' . $this->node->id() . '" data-view-mode="teaser">This placeholder should not be rendered.</div>';
     $settings = array();
     $settings['type'] = 'page';
     $settings['title'] = 'Test entity embed with entity-id and view-mode';
     $settings['body'] = array(array('value' => $content));
     $node = $this->drupalCreateNode($settings);
-
     $this->drupalGet('node/' . $node->id());
-
     $this->assertText($this->node->body->value, 'Embedded node exists in page');
     $this->assertNoText(strip_tags($content), 'Placeholder does not appears in the output when embed is successful.');
-  }
 
-  /**
-   * Tests entity embed using entity UUID and view mode.
-   */
-  public function testFilterUuidViewMode() {
+    // Tests entity embed using entity UUID and view mode.
     $content = '<div data-entity-type="node" data-entity-uuid="' . $this->node->uuid() . '" data-view-mode="teaser">This placeholder should not be rendered.</div>';
     $settings = array();
     $settings['type'] = 'page';
     $settings['title'] = 'Test entity embed with entity-uuid and view-mode';
     $settings['body'] = array(array('value' => $content));
     $node = $this->drupalCreateNode($settings);
-
     $this->drupalGet('node/' . $node->id());
-
     $this->assertText($this->node->body->value, 'Embedded node exists in page.');
     $this->assertNoText(strip_tags($content), 'Placeholder does not appears in the output when embed is successful.');
-  }
 
-  /**
-   * Tests that placeholder must not be replaced when embed is unsuccessful.
-   */
-  public function testFilterInvalidEntity() {
+    // Ensure that placeholder is not replaced when embed is unsuccessful.
     $content = '<div data-entity-type="node" data-entity-id="InvalidID" data-view-mode="teaser">This placeholder should be rendered since specified entity does not exists.</div>';
     $settings = array();
     $settings['type'] = 'page';
     $settings['title'] = 'Test that placeholder is retained when specified entity does not exists';
     $settings['body'] = array(array('value' => $content));
     $node = $this->drupalCreateNode($settings);
-
     $this->drupalGet('node/' . $node->id());
-
     $this->assertText(strip_tags($content), 'Placeholder appears in the output when embed is unsuccessful.');
-  }
 
-  /**
-   * Tests that UUID is preferred over ID when both attributes are present.
-   */
-  public function testFilterUuidPreference() {
+    // Ensure that UUID is preferred over ID when both attributes are present.
     $sample_node = $this->drupalCreateNode();
-
     $content = '<div data-entity-type="node" data-entity-id="' . $sample_node->id() . '" data-entity-uuid="' . $this->node->uuid() . '" data-view-mode="teaser">This placeholder should not be rendered.</div>';
     $settings = array();
     $settings['type'] = 'page';
     $settings['title'] = 'Test that entity-uuid is preferred over entity-id when both attributes are present';
     $settings['body'] = array(array('value' => $content));
     $node = $this->drupalCreateNode($settings);
-
     $this->drupalGet('node/' . $node->id());
-
     $this->assertText($this->node->body->value, 'Entity specifed with UUID exists in the page.');
     $this->assertNoText($sample_node->body->value, 'Entity specifed with ID does not exists in the page.');
     $this->assertNoText(strip_tags($content), 'Placeholder not appears in the output when embed is successful.');
-  }
 
-  /**
-   * Tests entity embed using display plugin.
-   */
-  public function testFilterDisplayPlugin() {
+    // Test entity embed using 'default' display plugin.
     $content = '<div data-entity-type="node" data-entity-uuid="' . $this->node->uuid() . '" data-entity-embed-display="default" data-entity-embed-settings=\'{"view_mode":"teaser"}\'>This placeholder should not be rendered.</div>';
     $settings = array();
     $settings['type'] = 'page';
     $settings['title'] = 'Test entity embed with entity-embed-display and data-entity-embed-settings';
     $settings['body'] = array(array('value' => $content));
     $node = $this->drupalCreateNode($settings);
-
     $this->drupalGet('node/' . $node->id());
-
     $this->assertText($this->node->body->value, 'Embedded node exists in page.');
     $this->assertNoText(strip_tags($content), 'Placeholder does not appears in the output when embed is successful.');
-  }
 
-  /**
-   * Tests that display plugin is preferred over view mode when both attributes are present.
-   */
-  public function testFilterDisplayPluginPreference() {
+    // Ensure that display plugin is preferred over view mode when both
+    // attributes are present.
     $content = '<div data-entity-type="node" data-entity-uuid="' . $this->node->uuid() . '" data-entity-embed-display="default" data-entity-embed-settings=\'{"view_mode":"teaser"}\' data-view-mode="some-invalid-view-mode">This placeholder should not be rendered.</div>';
     $settings = array();
     $settings['type'] = 'page';
     $settings['title'] = 'Test entity embed with entity-embed-display and data-entity-embed-settings';
     $settings['body'] = array(array('value' => $content));
     $node = $this->drupalCreateNode($settings);
-
     $this->drupalGet('node/' . $node->id());
-
     $this->assertText($this->node->body->value, 'Embedded node exists in page with the view mode specified by entity-embed-settings.');
     $this->assertNoText(strip_tags($content), 'Placeholder does not appears in the output when embed is successful.');
   }

--- a/src/Tests/EntityEmbedHooksTest.php
+++ b/src/Tests/EntityEmbedHooksTest.php
@@ -50,7 +50,6 @@ class EntityEmbedHooksTest extends EntityEmbedTestBase {
     // Enable entity_embed_test.module's hook_entity_preembed() implementation
     // and ensure it is working as designed.
     \Drupal::state()->set('entity_embed_test_entity_preembed', TRUE);
-    $description = "This is sample description";
     $content = '<div data-entity-type="node" data-entity-uuid="' . $this->node->uuid() . '" data-entity-embed-display="default" data-entity-embed-settings=\'{"view_mode":"teaser"}\'>This placeholder should not be rendered.</div>';
     $settings = array();
     $settings['type'] = 'page';
@@ -68,7 +67,6 @@ class EntityEmbedHooksTest extends EntityEmbedTestBase {
     // Enable entity_embed_test.module's hook_entity_embed_alter()
     // implementation and ensure it is working as designed.
     \Drupal::state()->set('entity_embed_test_entity_embed_alter', TRUE);
-    $description = "This is sample description";
     $content = '<div data-entity-type="node" data-entity-uuid="' . $this->node->uuid() . '" data-entity-embed-display="default" data-entity-embed-settings=\'{"view_mode":"teaser"}\'>This placeholder should not be rendered.</div>';
     $settings = array();
     $settings['type'] = 'page';
@@ -86,7 +84,6 @@ class EntityEmbedHooksTest extends EntityEmbedTestBase {
     // Enable entity_embed_test.module's hook_entity_embed_context_alter()
     // implementation and ensure it is working as designed.
     \Drupal::state()->set('entity_embed_test_entity_embed_context_alter', TRUE);
-    $description = "This is sample description";
     $content = '<div data-entity-type="node" data-entity-uuid="' . $this->node->uuid() . '" data-entity-embed-display="default" data-entity-embed-settings=\'{"view_mode":"teaser"}\'>This placeholder should not be rendered.</div>';
     $settings = array();
     $settings['type'] = 'page';

--- a/src/Tests/EntityEmbedPreviewTest.php
+++ b/src/Tests/EntityEmbedPreviewTest.php
@@ -14,6 +14,13 @@ namespace Drupal\entity_embed\Tests;
  */
 class EntityEmbedPreviewTest extends EntityEmbedTestBase {
 
+  /**
+   * URL of the preview route.
+   *
+   * @var string
+   */
+  protected $preview_url;
+
   protected function setUp() {
     parent::setUp();
 
@@ -22,35 +29,24 @@ class EntityEmbedPreviewTest extends EntityEmbedTestBase {
   }
 
   /**
-   * Tests preview route with a valid request.
+   * Tests the route used for generating preview of embedding entities.
    */
-  public function testPreviewController() {
+  public function testPreviewRoute() {
+    // Test preview route with a valid request.
     $content = '<div data-entity-type="node" data-entity-id="' . $this->node->id() . '" data-view-mode="teaser">This placeholder should not be rendered.</div>';
-
     $this->drupalGet($this->preview_url, array('query' => array('value' => $content)));
-
     $this->assertResponse(200, 'The preview route exists.');
     $this->assertText($this->node->body->value, 'Embedded node exists in page');
     $this->assertNoText(strip_tags($content), 'Placeholder does not appears in the output when embed is successful.');
-  }
 
-  /**
-   * Tests preview route with an invalid request.
-   */
-  public function testPreviewControllerInvalidRequest() {
+    // Test preview route with an invalid request.
     $content = 'Testing preview route without valid values';
     $this->drupalGet($this->preview_url, array('query' => array('value' => $content)));
-
     $this->assertResponse(200, 'The preview route exists.');
     $this->assertText($content, 'Placeholder appears in the output when embed is unsuccessful.');
-  }
 
-  /**
-   * Tests preview route with an empty request.
-   */
-  public function testPreviewControllerEmptyRequest() {
+    // Test preview route with an empty request.
     $this->drupalGet($this->preview_url);
-
     $this->assertResponse(404, "The preview returns 'Page not found' when GET parameters are not provided.");
   }
 


### PR DESCRIPTION
Some code cleanup to existing tests - FilterTest and PreviewTest. Moved tests inside a single method in both classes since the individual tests did not required separate testing environments.

Also, this PR removes some unused variables from code.
