### PR TITLE
Rename tag of container elemet to div if it was drupal-entity

### DIFF
--- a/src/Plugin/Filter/EntityEmbedFilter.php
+++ b/src/Plugin/Filter/EntityEmbedFilter.php
@@ -77,27 +77,7 @@ class EntityEmbedFilter extends FilterBase implements ContainerFactoryPluginInte
         $entity_type = $node->getAttribute('data-entity-type');
         $entity = NULL;
 
-        watchdog('old', $node->tagName);
         try {
-          // Rename tag of container elemet to 'div' if it was 'drupal-entity'.
-          if ($node->tagName == 'drupal-entity') {
-            $new_node = $node->ownerDocument->createElement('div');
-            // Copy all attributes of original node to new node.
-            if ($node->attributes->length) {
-              foreach ($node->attributes as $attribute) {
-                $new_node->setAttribute($attribute->nodeName, $attribute->nodeValue);
-              }
-            }
-            // Copy all the childern of original node to new node.
-            while ($node->firstChild) {
-              $new_node->appendChild($node->firstChild);
-            }
-            $node->parentNode->replaceChild($new_node, $node);
-
-            // Rename new node's variable to be used later as $node.
-            $node = $new_node;
-          }
-
           // Load the entity either by UUID (preferred) or ID.
           $id = $node->getAttribute('data-entity-uuid') ?: $node->getAttribute('data-entity-id');
           $entity = $this->loadEntity($entity_type, $id);
@@ -231,6 +211,22 @@ class EntityEmbedFilter extends FilterBase implements ContainerFactoryPluginInte
     // Remove all children of the DOMNode.
     while ($node->hasChildNodes()) {
       $node->removeChild($node->firstChild);
+    }
+
+    // Rename tag of container elemet to 'div' if it was 'drupal-entity'.
+    if ($node->tagName == 'drupal-entity') {
+      $new_node = $node->ownerDocument->createElement('div');
+
+      // Copy all attributes of original node to new node.
+      if ($node->attributes->length) {
+        foreach ($node->attributes as $attribute) {
+          $new_node->setAttribute($attribute->nodeName, $attribute->nodeValue);
+        }
+      }
+
+      $node->parentNode->replaceChild($new_node, $node);
+
+      $node = $new_node;
     }
 
     // Finally, append the contents to the DOMNode.

--- a/src/Plugin/Filter/EntityEmbedFilter.php
+++ b/src/Plugin/Filter/EntityEmbedFilter.php
@@ -77,7 +77,27 @@ class EntityEmbedFilter extends FilterBase implements ContainerFactoryPluginInte
         $entity_type = $node->getAttribute('data-entity-type');
         $entity = NULL;
 
+        watchdog('old', $node->tagName);
         try {
+          // Rename tag of container elemet to 'div' if it was 'drupal-entity'.
+          if ($node->tagName == 'drupal-entity') {
+            $new_node = $node->ownerDocument->createElement('div');
+            // Copy all attributes of original node to new node.
+            if ($node->attributes->length) {
+              foreach ($node->attributes as $attribute) {
+                $new_node->setAttribute($attribute->nodeName, $attribute->nodeValue);
+              }
+            }
+            // Copy all the childern of original node to new node.
+            while ($node->firstChild) {
+              $new_node->appendChild($node->firstChild);
+            }
+            $node->parentNode->replaceChild($new_node, $node);
+
+            // Rename new node's variable to be used later as $node.
+            $node = $new_node;
+          }
+
           // Load the entity either by UUID (preferred) or ID.
           $id = $node->getAttribute('data-entity-uuid') ?: $node->getAttribute('data-entity-id');
           $entity = $this->loadEntity($entity_type, $id);

--- a/src/Tests/EntityEmbedFilterTest.php
+++ b/src/Tests/EntityEmbedFilterTest.php
@@ -95,7 +95,7 @@ class EntityEmbedFilterTest extends EntityEmbedTestBase {
     $settings['type'] = 'page';
     $settings['title'] = 'test entity embed with entity-id and view-mode';
     $settings['body'] = array(array('value' => $content));
-    $node = $this->drupalcreatenode($settings);
+    $node = $this->drupalCreateNode($settings);
     $this->drupalget('node/' . $node->id());
     $this->asserttext($this->node->body->value, 'embedded node exists in page');
     $this->assertNoRaw('</drupal-entity>');
@@ -107,7 +107,7 @@ class EntityEmbedFilterTest extends EntityEmbedTestBase {
     $settings['type'] = 'page';
     $settings['title'] = 'test entity embed with entity-id and view-mode';
     $settings['body'] = array(array('value' => $content));
-    $node = $this->drupalcreatenode($settings);
+    $node = $this->drupalCreateNode($settings);
     $this->drupalget('node/' . $node->id());
     $this->asserttext($this->node->body->value, 'embedded node exists in page');
     $this->assertRaw('</not-drupal-entity>');

--- a/src/Tests/EntityEmbedFilterTest.php
+++ b/src/Tests/EntityEmbedFilterTest.php
@@ -88,6 +88,29 @@ class EntityEmbedFilterTest extends EntityEmbedTestBase {
     $this->drupalGet('node/' . $node->id());
     $this->assertText($this->node->body->value, 'Embedded node exists in page with the view mode specified by entity-embed-settings.');
     $this->assertNoText(strip_tags($content), 'Placeholder does not appears in the output when embed is successful.');
+
+    // Test that tag of container element is replaced when it's 'drupal-entity'.
+    $content = '<drupal-entity data-entity-type="node" data-entity-id="' . $this->node->id() . '" data-view-mode="teaser">this placeholder should not be rendered.</drupal-entity>';
+    $settings = array();
+    $settings['type'] = 'page';
+    $settings['title'] = 'test entity embed with entity-id and view-mode';
+    $settings['body'] = array(array('value' => $content));
+    $node = $this->drupalcreatenode($settings);
+    $this->drupalget('node/' . $node->id());
+    $this->asserttext($this->node->body->value, 'embedded node exists in page');
+    $this->assertNoRaw('</drupal-entity>');
+
+    // Test that tag of container element is not replaced when it's not
+    // 'drupal-entity'.
+    $content = '<not-drupal-entity data-entity-type="node" data-entity-id="' . $this->node->id() . '" data-view-mode="teaser">this placeholder should not be rendered.</not-drupal-entity>';
+    $settings = array();
+    $settings['type'] = 'page';
+    $settings['title'] = 'test entity embed with entity-id and view-mode';
+    $settings['body'] = array(array('value' => $content));
+    $node = $this->drupalcreatenode($settings);
+    $this->drupalget('node/' . $node->id());
+    $this->asserttext($this->node->body->value, 'embedded node exists in page');
+    $this->assertRaw('</not-drupal-entity>');
   }
 
 }


### PR DESCRIPTION
d.o issue: https://www.drupal.org/node/2307553
Follow-up to: #82

Since it's not possible to rename a DOM node directly, first a new node is created and all attributes/children of parent node are copied to the new node. Then we replace the original node with the new node.
