### PR TITLE
Rename controllers according to core changes in #2200867

### DIFF
--- a/src/Entity/EmbedButton.php
+++ b/src/Entity/EmbedButton.php
@@ -17,7 +17,7 @@ use Drupal\entity_embed\EntityHelperTrait;
  * @ConfigEntityType(
  *   id = "embed_button",
  *   label = @Translation("Embed Button"),
- *   controllers = {
+ *   handlers = {
  *     "list_builder" = "Drupal\entity_embed\EmbedButtonListBuilder",
  *     "form" = {
  *       "add" = "Drupal\entity_embed\Form\EmbedButtonForm",

--- a/src/EntityHelperTrait.php
+++ b/src/EntityHelperTrait.php
@@ -108,7 +108,7 @@ trait EntityHelperTrait {
    */
   protected function canRenderEntity(EntityInterface $entity) {
     $entity_type = $entity->getEntityTypeId();
-    return $this->entityManager()->hasController($entity_type, 'view_builder');
+    return $this->entityManager()->hasHandler($entity_type, 'view_builder');
   }
 
   /**

--- a/src/Tests/EmbedButtonCrudTest.php
+++ b/src/Tests/EmbedButtonCrudTest.php
@@ -23,7 +23,7 @@ class EmbedButtonCrudTest extends KernelTestBase {
    *
    * @var array
    */
-  public static $modules = array('entity_embed', 'node');
+  public static $modules = array('entity_embed');
 
   /**
    * The embed button storage.


### PR DESCRIPTION
Recent core changes listed in https://www.drupal.org/node/2200867 renamed entity controllers to handlers.

This PR addresses those changes and fixes the recent test failures.
