### PR TITLE
Previewing an entity in the WYSIWYG does not add any attached styles or javascript from the AJAX callback

### DIFF
--- a/js/plugins/drupalentity/plugin.js
+++ b/js/plugins/drupalentity/plugin.js
@@ -111,7 +111,7 @@
           // Only keep the wrapping element.
           element.setHtml('');
           // Remove the auto-generated ID.
-          element.removeAttribute('id');
+          delete element.attributes.id;
           return element;
         },
       });

--- a/js/plugins/drupalentity/plugin.js
+++ b/js/plugins/drupalentity/plugin.js
@@ -81,6 +81,9 @@
           if (attributes['data-entity-type'] === undefined || (attributes['data-entity-id'] === undefined && attributes['data-entity-uuid'] === undefined)) {
             return;
           }
+          // Generate an ID for the element, so that we can use the Ajax
+          // framework.
+          element.attributes.id = generateEmbedId();
           return element;
         },
 
@@ -89,11 +92,8 @@
           var element = this.element;
           var $element = $(element.$);
           // Use the Ajax framework to fetch the HTML, so that we can retrieve
-          // out-of-band assets (JS, CSS...). This requires the element to have
-          // an ID.
-          var id = generateEmbedId();
-          element.setAttribute('id', id);
-          new Drupal.ajax(id, $element, {
+          // out-of-band assets (JS, CSS...).
+          new Drupal.ajax($element.attr('id'), $element, {
             url: Drupal.url('entity-embed/preview/' + editor.config.drupal.format + '?' + $.param({
               value: element.getOuterHtml()
             })),

--- a/src/Ajax/EntityEmbedInsertCommand.php
+++ b/src/Ajax/EntityEmbedInsertCommand.php
@@ -2,10 +2,10 @@
 
 /**
  * @file
- * Contains \Drupal\entity_embed\EntityEmbedInsertCommand.
+ * Contains \Drupal\entity_embed\Ajax\EntityEmbedInsertCommand.
  */
 
-namespace Drupal\entity_embed;
+namespace Drupal\entity_embed\Ajax;
 
 use Drupal\Core\Ajax\CommandInterface;
 

--- a/src/EntityEmbedController.php
+++ b/src/EntityEmbedController.php
@@ -9,8 +9,9 @@ namespace Drupal\entity_embed;
 
 use Drupal\Core\Ajax\AjaxResponse;
 use Drupal\Core\Controller\ControllerBase;
-use Symfony\Component\HttpFoundation\Request;
+use Drupal\entity_embed\Ajax\EntityEmbedInsertCommand;
 use Drupal\filter\FilterFormatInterface;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 /**

--- a/src/EntityEmbedController.php
+++ b/src/EntityEmbedController.php
@@ -7,8 +7,8 @@
 
 namespace Drupal\entity_embed;
 
+use Drupal\Core\Ajax\AjaxResponse;
 use Drupal\Core\Controller\ControllerBase;
-use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Drupal\filter\FilterFormatInterface;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
@@ -41,9 +41,10 @@ class EntityEmbedController extends ControllerBase {
     }
 
     $entity_output = check_markup($text, $filter_format->id());
-    return new JsonResponse(array(
-      'content' => $entity_output,
-    ));
+
+    $response = new AjaxResponse();
+    $response->addCommand(new EntityEmbedInsertCommand($entity_output));
+    return $response;
   }
 
 }

--- a/src/EntityEmbedInsertCommand.php
+++ b/src/EntityEmbedInsertCommand.php
@@ -1,0 +1,46 @@
+<?php
+
+/**
+ * @file
+ * Contains \Drupal\entity_embed\EntityEmbedInsertCommand.
+ */
+
+namespace Drupal\entity_embed;
+
+use Drupal\Core\Ajax\CommandInterface;
+
+/**
+ * AJAX command for inserting an embedded entity in a CKEditor.
+ *
+ * @ingroup ajax
+ */
+class EntityEmbedInsertCommand implements CommandInterface {
+
+  /**
+   * The HTML content that will replace the matched element(s).
+   *
+   * @var string
+   */
+  protected $html;
+
+  /**
+   * Constructs an EntityEmbedCommand object.
+   *
+   * @param string $html
+   *   String of HTML to be inserted.
+   */
+  public function __construct($html) {
+    $this->html = $html;
+  }
+
+  /**
+   * Implements Drupal\Core\Ajax\CommandInterface:render().
+   */
+  public function render() {
+    return array(
+      'command' => 'entity_embed_insert',
+      'html' => $this->html,
+    );
+  }
+
+}


### PR DESCRIPTION
PR for https://www.drupal.org/node/2350463

This uses the ajax framework to fetch the previewed entities in the wysiwig. Code is adapted from the work I did on scald D7 for a client (https://www.drupal.org/node/2136415). 

This allows:
- Adding the assets (JS / CSS) for the rendered entity. Works beautifully when the CKeditor is in divarea mode. In iframe mode, the CSS do not get applied to the content of the iframe, but that is to be expected
- Attaching JS behaviors (e.g a picturefill, an image lazy-loading script...). Works fine as well, even in iframe mode, because Drupal.attachBehaviors() is called on an element in the iframe, so `$(selector, context)` works as expected.
  (`$(selector)` runs from the parent document and cannot see the content of the iframe, 
  but `$(selector, SomeElementInTheIframe)` works as expected)

Works a little too well, actually : 
- embedding a node triggers the "contextual links" behavior, which, when unstyled (in the iframe mode D8 uses by default), looks weird.
- embedding a node in a view mode that displays the comment form (!) triggers JS errors in editor.js, because its attach/detach code deesn't fully pass the context to its jquery selectors. Will open a core issue for that.

[edit: those issues have been fixed in latest code - see [comment below](https://github.com/drupal-media/entity_embed/pull/103#issuecomment-60486887)]
