### PR TITLE
Use lower case and underscores instead of camel casing for variable names

### DIFF
--- a/src/EntityHelperTrait.php
+++ b/src/EntityHelperTrait.php
@@ -252,8 +252,8 @@ trait EntityHelperTrait {
    *
    * @return self
    */
-  public function setEntityManager(EntityManagerInterface $entityManager) {
-    $this->entityManager = $entityManager;
+  public function setEntityManager(EntityManagerInterface $entity_manager) {
+    $this->entityManager = $entity_manager;
     return $this;
   }
 
@@ -278,8 +278,8 @@ trait EntityHelperTrait {
    *
    * @return self
    */
-  public function setModuleHandler(ModuleHandlerInterface $moduleHandler) {
-    $this->moduleHandler = $moduleHandler;
+  public function setModuleHandler(ModuleHandlerInterface $module_handler) {
+    $this->moduleHandler = $module_handler;
     return $this;
   }
 
@@ -304,8 +304,8 @@ trait EntityHelperTrait {
    *
    * @return self
    */
-  public function setDisplayPluginManager(EntityEmbedDisplayManager $displayPluginManager) {
-    $this->displayPluginManager = $displayPluginManager;
+  public function setDisplayPluginManager(EntityEmbedDisplayManager $display_plugin_manager) {
+    $this->displayPluginManager = $display_plugin_manager;
     return $this;
   }
 }

--- a/src/Plugin/Derivative/FieldFormatterDeriver.php
+++ b/src/Plugin/Derivative/FieldFormatterDeriver.php
@@ -32,8 +32,8 @@ class FieldFormatterDeriver extends DeriverBase implements ContainerDeriverInter
    * @param \Drupal\Core\Field\FormatterPluginManager $formatterManager
    *   The field formatter plugin manager.
    */
-  public function __construct(FormatterPluginManager $formatterManager) {
-    $this->formatterManager = $formatterManager;
+  public function __construct(FormatterPluginManager $formatter_manager) {
+    $this->formatterManager = $formatter_manager;
   }
 
   /**


### PR DESCRIPTION
drupal.org issue link: https://www.drupal.org/node/2445737
