### PR TITLE
Fix serialization exceptions on form submission

### DIFF
--- a/entity_embed.services.yml
+++ b/entity_embed.services.yml
@@ -2,3 +2,7 @@ services:
   plugin.manager.entity_embed.display:
     class: Drupal\entity_embed\EntityEmbedDisplay\EntityEmbedDisplayManager
     arguments: ['@container.namespaces', '@cache.discovery', '@module_handler']
+  logger.channel.entity_embed:
+      class: Drupal\Core\Logger\LoggerChannel
+      factory: logger.factory:get
+      arguments: ['entity_embed']

--- a/src/Form/EntityEmbedDialog.php
+++ b/src/Form/EntityEmbedDialog.php
@@ -67,7 +67,7 @@ class EntityEmbedDialog extends FormBase {
     return new static(
       $container->get('plugin.manager.entity_embed.display'),
       $container->get('form_builder'),
-      $container->get('logger.factory')->get('entity_embed')
+      $container->get('logger.channel.entity_embed')
     );
   }
 


### PR DESCRIPTION
The problem is that DependencySerializationTrait can only deal with services, because only those have the magic _serviceId property that it needs.

Registering the log channel as a service with a factory makes the form work again for me. Let's see if that also helps with fixing some of those test fails.
