### PR TITLE
Removed EntityHelperTrait::accessEntity().

### DIFF
--- a/src/EntityEmbedDisplay/EntityEmbedDisplayBase.php
+++ b/src/EntityEmbedDisplay/EntityEmbedDisplayBase.php
@@ -75,12 +75,9 @@ abstract class EntityEmbedDisplayBase extends PluginBase implements ContainerFac
     }
 
     // Check that the entity itself can be viewed by the user.
-    // This uses the accessEntity method on the helper trait instead of
-    // Entity::access() because there are bugs with file access.
-    if ($this->hasContextValue('entity')) {
-      return $this->accessEntity($this->getContextValue('entity'), 'view', $account);
-    }
-    return TRUE;
+    /** @var \Drupal\Core\Entity\EntityInterface $entity */
+    $entity = $this->getContextValue('entity');
+    return $entity->access('view', $account);
   }
 
   /**

--- a/src/EntityEmbedDisplay/EntityEmbedDisplayBase.php
+++ b/src/EntityEmbedDisplay/EntityEmbedDisplayBase.php
@@ -75,9 +75,11 @@ abstract class EntityEmbedDisplayBase extends PluginBase implements ContainerFac
     }
 
     // Check that the entity itself can be viewed by the user.
-    /** @var \Drupal\Core\Entity\EntityInterface $entity */
-    $entity = $this->getContextValue('entity');
-    return $entity->access('view', $account);
+    if ($entity = $this->getEntityFromContext()) {
+      return $entity->access('view', $account);
+    }
+
+    return TRUE;
   }
 
   /**
@@ -235,7 +237,7 @@ abstract class EntityEmbedDisplayBase extends PluginBase implements ContainerFac
   }
 
   /**
-   * Gets the entity type from a defined context.
+   * Gets the entity type from the current context.
    *
    * @return string
    *   The entity type id.
@@ -246,6 +248,17 @@ abstract class EntityEmbedDisplayBase extends PluginBase implements ContainerFac
     }
     else {
       return $this->getContextValue('entity_type');
+    }
+  }
+
+  /**
+   * Gets the entity from the current context.
+   *
+   * @return \Drupal\Core\Entity\EntityInterface
+   */
+  public function getEntityFromContext() {
+    if ($this->hasContextValue('entity')) {
+      return $this->getContextValue('entity');
     }
   }
 

--- a/src/EntityHelperTrait.php
+++ b/src/EntityHelperTrait.php
@@ -229,40 +229,6 @@ trait EntityHelperTrait {
   }
 
   /**
-   * Check access to an entity.
-   *
-   * @todo Remove when https://www.drupal.org/node/2533978 is fixed in core.
-   *
-   * @param \Drupal\Core\Entity\EntityInterface $entity
-   *   The entity object.
-   * @param string $op
-   *   (optional) The operation to be performed. Defaults to view.
-   * @param \Drupal\Core\Session\AccountInterface $account
-   *   (optional) The user for which to check access, or NULL to check access
-   *   for the current user. Defaults to NULL.
-   * @param bool $return_as_object
-   *   (optional) Defaults to FALSE.
-   *
-   * @return bool|\Drupal\Core\Access\AccessResultInterface
-   *   The access result. Returns a boolean if $return_as_object is FALSE (this
-   *   is the default) and otherwise an AccessResultInterface object.
-   *   When a boolean is returned, the result of AccessInterface::isAllowed() is
-   *   returned, i.e. TRUE means access is explicitly allowed, FALSE means
-   *   access is either explicitly forbidden or "no opinion".
-   */
-  protected function accessEntity(EntityInterface $entity, $op = 'view', AccountInterface $account = NULL, $return_as_object = FALSE) {
-    if ($entity->getEntityTypeId() === 'file') {
-      /** @var \Drupal\file\Entity\File $entity */
-      $uri = $entity->getFileUri();
-      if (\Drupal::service('file_system')->uriScheme($uri) === 'public') {
-        return $return_as_object ? AccessResult::allowed() : TRUE;
-      }
-    }
-
-    return $entity->access($op, $account, $return_as_object);
-  }
-
-  /**
    * Returns the entity manager.
    *
    * @return \Drupal\Core\Entity\EntityManagerInterface

--- a/src/EntityHelperTrait.php
+++ b/src/EntityHelperTrait.php
@@ -7,13 +7,11 @@
 
 namespace Drupal\entity_embed;
 
-use Drupal\Core\Access\AccessResult;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\EntityManagerInterface;
 use Drupal\Core\Entity\EntityStorageException;
 use Drupal\Core\Extension\ModuleHandlerInterface;
 use Drupal\Core\Render\RendererInterface;
-use Drupal\Core\Session\AccountInterface;
 use Drupal\entity_embed\EntityEmbedDisplay\EntityEmbedDisplayManager;
 
 /**

--- a/src/Form/EntityEmbedDialog.php
+++ b/src/Form/EntityEmbedDialog.php
@@ -361,7 +361,7 @@ class EntityEmbedDialog extends FormBase {
     if ($entity_type = $values['attributes']['data-entity-type']) {
       $id = trim($values['attributes']['data-entity-id']);
       if ($entity = $this->loadEntity($entity_type, $id)) {
-        if (!$this->accessEntity($entity, 'view')) {
+        if (!$entity->access('view')) {
           $form_state->setError($form['attributes']['data-entity-id'], $this->t('Unable to access @type entity @id.', array('@type' => $entity_type, '@id' => $id)));
         }
         else {

--- a/src/Plugin/Filter/EntityEmbedFilter.php
+++ b/src/Plugin/Filter/EntityEmbedFilter.php
@@ -101,10 +101,7 @@ class EntityEmbedFilter extends FilterBase implements ContainerFactoryPluginInte
               $node->setAttribute('data-entity-uuid', $uuid);
             }
 
-            // Do not use $entity->access() here because it does not work with
-            // public files. Uses EntityHelperTrait::accessEntity() instead.
-            // @see https://www.drupal.org/node/2533978
-            $access = $this->accessEntity($entity, 'view', NULL, TRUE);
+            $access = $entity->access('view', NULL, TRUE);
             $access_metadata = CacheableMetadata::createFromObject($access);
             $entity_metadata = CacheableMetadata::createFromObject($entity);
             $result = $result->merge($entity_metadata)->merge($access_metadata);

--- a/src/Plugin/entity_embed/EntityEmbedDisplay/FileFieldFormatter.php
+++ b/src/Plugin/entity_embed/EntityEmbedDisplay/FileFieldFormatter.php
@@ -61,4 +61,13 @@ class FileFieldFormatter extends EntityReferenceFieldFormatter {
     return $form;
   }
 
+  /**
+   * {@inheritdoc}
+   *
+   * @return \Drupal\file\FileInterface
+   */
+  public function getEntityFromContext() {
+    return parent::getEntityFromContext();
+  }
+
 }

--- a/src/Plugin/entity_embed/EntityEmbedDisplay/ImageFieldFormatter.php
+++ b/src/Plugin/entity_embed/EntityEmbedDisplay/ImageFieldFormatter.php
@@ -89,11 +89,10 @@ class ImageFieldFormatter extends FileFieldFormatter {
       return FALSE;
     }
 
-    if ($this->hasContextValue('entity')) {
-      $uri = $this->getContextValue('entity')->getFileUri();
-      $image = $this->imageFactory->get($uri);
-      return $image->isValid();
+    if ($entity = $this->getEntityFromContext()) {
+      return $this->imageFactory->get($entity->getFileUri())->isValid();
     }
+
     return TRUE;
   }
 


### PR DESCRIPTION
Now that https://www.drupal.org/node/2533978 is fixed in core, we no longer have any issues with just calling $entity->access() for public files.
