### PR TITLE
Added an entity embed service.

### DIFF
--- a/entity_embed.api.php
+++ b/entity_embed.api.php
@@ -50,7 +50,7 @@ function hook_entity_embed_display_plugins_for_context_alter(array &$definitions
 
   // For nodes, use the default option.
   if ($entity instanceof \Drupal\node\NodeInterface) {
-    $definitions = array_intersect_key($definitions, array_flip(['entity_reference:entity_reference_entity_view']));
+    $definitions = array_intersect_key($definitions, array_flip([\Drupal\entity_embed\EntityEmbedInterface::DEFAULT_DISPLAY_ID]));
   }
 }
 

--- a/entity_embed.services.yml
+++ b/entity_embed.services.yml
@@ -2,3 +2,6 @@ services:
   plugin.manager.entity_embed.display:
     class: Drupal\entity_embed\EntityEmbedDisplay\EntityEmbedDisplayManager
     arguments: ['@container.namespaces', '@cache.discovery', '@module_handler']
+  entity_embed:
+    class: Drupal\entity_embed\EntityEmbed
+    arguments: ['@entity.manager', '@module_handler', '@renderer', '@plugin.manager.entity_embed.display']

--- a/src/EntityEmbed.php
+++ b/src/EntityEmbed.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace Drupal\entity_embed;
+
+use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
+use Drupal\Core\Entity\EntityManagerInterface;
+use Drupal\Core\Extension\ModuleHandlerInterface;
+use Drupal\Core\Render\RendererInterface;
+use Drupal\entity_embed\EntityEmbedDisplay\EntityEmbedDisplayManager;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Drupal\Core\Entity\EntityInterface;
+
+class EntityEmbedService implements EntityEmbedInterface, ContainerInjectionInterface {
+  use EntityHelperTrait;
+
+  /**
+   * The renderer.
+   *
+   * @var \Drupal\Core\Render\RendererInterface.
+   */
+  protected $renderer;
+
+  /**
+   * The display plugin manager.
+   *
+   * @var \Drupal\entity_embed\EntityEmbedDisplay\EntityEmbedDisplayManager.
+   */
+  protected $displayPluginManager;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function __construct(EntityManagerInterface $entity_manager, ModuleHandlerInterface $module_handler, RendererInterface $renderer, EntityEmbedDisplayManager $display_plugin_manager) {
+    $this->setEntityManager($entity_manager);
+    $this->setModuleHandler($module_handler);
+    $this->renderer = $renderer;
+    $this->displayPluginManager = $display_plugin_manager;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('entity.manager'),
+      $container->get('module_handler'),
+      $container->get('renderer'),
+      $container->get('plugin.manager.entity_embed.display')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function renderEntityEmbed(EntityInterface $entity, array $context = array()) {
+    // Merge in default attributes.
+    $context += array(
+      'data-entity-id' => $entity->id(),
+      'data-entity-type' => $entity->getEntityTypeId(),
+      'data-entity-embed-display' => static::DEFAULT_DISPLAY_ID,
+      'data-entity-embed-settings' => array(),
+    );
+
+    // The default display plugin has been deprecated by the rendered entity
+    // field formatter.
+    if ($context['data-entity-embed-display'] === 'default') {
+      $context['data-entity-embed-display'] = static::DEFAULT_DISPLAY_ID;
+    }
+
+    // Support the deprecated view-mode data attribute.
+    if (isset($context['data-view-mode']) && $context['data-entity-embed-display'] === static::DEFAULT_DISPLAY_ID && empty($context['data-entity-embed-settings'])) {
+      $context['data-entity-embed-settings']['view_mode'] = &$context['data-view-mode'];
+    }
+
+    // Allow modules to alter the entity prior to embed rendering.
+    $this->moduleHandler()->alter(array("{$context['data-entity-type']}_embed_context", 'entity_embed_context'), $context, $entity);
+
+    // Build and render the display plugin, allowing modules to alter the
+    // result before rendering.
+    $build = $this->renderEntityEmbedDisplayPlugin(
+      $entity,
+      $context['data-entity-embed-display'],
+      $context['data-entity-embed-settings'],
+      $context
+    );
+    // @todo Should this hook get invoked if $build is an empty array?
+    $this->moduleHandler()->alter(array("{$context['data-entity-type']}_embed", 'entity_embed'), $build, $entity, $context);
+    $entity_output = $this->renderer->render($build);
+
+    return $entity_output;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function renderEntityEmbedDisplayPlugin(EntityInterface $entity, $plugin_id, array $plugin_configuration = array(), array $context = array()) {
+    // Build the display plugin.
+    /** @var \Drupal\entity_embed\EntityEmbedDisplay\EntityEmbedDisplayBase $display */
+    $display = $this->displayPluginManager->createInstance($plugin_id, $plugin_configuration);
+    $display->setContextValue('entity', $entity);
+    $display->setAttributes($context);
+
+    // Check if the display plugin is accessible. This also checks entity
+    // access, which is why we never call $entity->access() here.
+    if (!$display->access()) {
+      return array();
+    }
+
+    return $display->build();
+  }
+}

--- a/src/EntityEmbedInterface.php
+++ b/src/EntityEmbedInterface.php
@@ -1,0 +1,71 @@
+<?php
+
+/**
+ * @file
+ * Contains Drupal\entity_embed\EntityEmbedInterface.
+ */
+
+namespace Drupal\entity_embed;
+
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Entity\EntityManagerInterface;
+use Drupal\Core\Extension\ModuleHandlerInterface;
+use Drupal\Core\Render\RendererInterface;
+use Drupal\entity_embed\EntityEmbedDisplay\EntityEmbedDisplayManager;
+
+/**
+ * A service class for handling entity embeds.
+ *
+ * @todo Add more documentation.
+ */
+interface EntityEmbedInterface {
+
+  const DEFAULT_DISPLAY_ID = 'entity_reference:entity_reference_entity_view';
+
+  /**
+   * Constructs a EntityEmbedService object.
+   *
+   * @param \Drupal\Core\Entity\EntityManagerInterface $entity_manager
+   *   The entity manager service.
+   * @param \Drupal\Core\Extension\ModuleHandlerInterface $module_handler
+   *   The module handler.
+   * @param \Drupal\Core\Render\RendererInterface $renderer
+   *   The renderer.
+   * @param \Drupal\entity_embed\EntityEmbedDisplay\EntityEmbedDisplayManager $display_plugin_manager
+   *   The entity embed display plugin manager.
+   */
+  public function __construct(EntityManagerInterface $entity_manager, ModuleHandlerInterface $module_handler, RendererInterface $renderer, EntityEmbedDisplayManager $display_plugin_manager);
+
+  /**
+   * Renders an embedded entity.
+   *
+   * @param \Drupal\Core\Entity\EntityInterface $entity
+   *   The entity to be rendered.
+   * @param array $context
+   *   (optional) Array of context values, corresponding to the attributes on
+   *   the embed HTML tag.
+   *
+   * @return string
+   *   The HTML of the entity rendered with the display plugin.
+   */
+  public function renderEntityEmbed(EntityInterface $entity, array $context = array());
+
+  /**
+   * Renders an entity using an EntityEmbedDisplay plugin.
+   *
+   * @param \Drupal\Core\Entity\EntityInterface $entity
+   *   The entity to be rendered.
+   * @param string $plugin_id
+   *   The EntityEmbedDisplay plugin ID.
+   * @param array $plugin_configuration
+   *   (optional) Array of plugin configuration values.
+   * @param array $context
+   *   (optional) Array of additional context values, usually the embed HTML
+   *   tag's attributes.
+   *
+   * @return array
+   *   A render array for the display plugin.
+   */
+  public function renderEntityEmbedDisplayPlugin(EntityInterface $entity, $plugin_id, array $plugin_configuration = array(), array $context = array());
+
+}

--- a/src/Plugin/Filter/EntityEmbedFilter.php
+++ b/src/Plugin/Filter/EntityEmbedFilter.php
@@ -12,6 +12,7 @@ use Drupal\Core\Entity\EntityManagerInterface;
 use Drupal\Core\Extension\ModuleHandlerInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\Core\Cache\CacheableMetadata;
+use Drupal\entity_embed\EntityEmbedInterface;
 use Drupal\entity_embed\EntityHelperTrait;
 use Drupal\entity_embed\Exception\EntityNotFoundException;
 use Drupal\entity_embed\Exception\RecursiveRenderingException;
@@ -35,6 +36,13 @@ class EntityEmbedFilter extends FilterBase implements ContainerFactoryPluginInte
   use DomHelperTrait;
 
   /**
+   * The entity embed service.
+   *
+   * @var \Drupal\entity_embed\EntityEmbedInterface.
+   */
+  protected $entityEmbed;
+
+  /**
    * Constructs a EntityEmbedFilter object.
    *
    * @param array $configuration
@@ -45,13 +53,13 @@ class EntityEmbedFilter extends FilterBase implements ContainerFactoryPluginInte
    *   The plugin implementation definition.
    * @param \Drupal\Core\Entity\EntityManagerInterface $entity_manager
    *   The entity manager service.
-   * @param \Drupal\Core\Extension\ModuleHandlerInterface $module_handler
-   *   The Module Handler.
+   * @param \Drupal\entity_embed\EntityEmbedInterface $entity_embed
+   *   The entity embed service.
    */
-  public function __construct(array $configuration, $plugin_id, $plugin_definition, EntityManagerInterface $entity_manager, ModuleHandlerInterface $module_handler) {
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, EntityManagerInterface $entity_manager, EntityEmbedInterface $entity_embed) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
     $this->setEntityManager($entity_manager);
-    $this->setModuleHandler($module_handler);
+    $this->entityEmbed = $entity_embed;
   }
 
   /**
@@ -63,7 +71,7 @@ class EntityEmbedFilter extends FilterBase implements ContainerFactoryPluginInte
       $plugin_id,
       $plugin_definition,
       $container->get('entity.manager'),
-      $container->get('module_handler')
+      $container->get('entity_embed')
     );
   }
 
@@ -108,7 +116,7 @@ class EntityEmbedFilter extends FilterBase implements ContainerFactoryPluginInte
 
             $context = $this->getNodeAttributesAsArray($node);
             $context += array('data-langcode' => $langcode);
-            $entity_output = $this->renderEntityEmbed($entity, $context);
+            $entity_output = $this->entityEmbed->renderEntityEmbed($entity, $context);
 
             $depth--;
           }


### PR DESCRIPTION
I thought it would be good to separate out the actual rendering part to a service that could be overridden. The main benefit I was thinking of is having a constant for the default display plugin ID. But I could just as easily add that to `EntityEmbedDisplayManager`.
