### PR TITLE
define allowedContent on button to automatically add allowed content tag in list

### DIFF
--- a/js/plugins/drupalentity/plugin.js
+++ b/js/plugins/drupalentity/plugin.js
@@ -136,6 +136,7 @@
           editor.ui.addButton(button.id, {
             label: button.label,
             data: button,
+            allowedContent: 'drupal-entity[!data-entity-type,!data-entity-id,!data-entity-uuid,!data-entity-embed-display,!data-entity-embed-settings]',
             click: function(editor) {
               editor.execCommand('editdrupalentity', this.data);
             },


### PR DESCRIPTION
According to this comment (https://www.drupal.org/node/2554687#comment-10330983) the functionality to automatically add the drupal-entity tag to the list of allowed content for HTML-correction needs to be added by defining this on the button itself due to the fact that these buttons/commands are not individually defined.

I tested that as you can see in this PR and when you now add the button to the editor toolbar you get the desired result.
I had to specify the attributes as required (!) otherwise only <drupal-entity> without attributes would have been added to the list.

I am not sure, if we can now get rid of the definition of the allowedContent attribute in other places, but that might need further testing.

Please review!
