### PR TITLE
AJAX errors when embedding entities with Entity Browser

### DIFF
--- a/entity_embed.info.yml
+++ b/entity_embed.info.yml
@@ -7,3 +7,5 @@ dependencies:
   - editor
   - embed
   - filter
+test_dependencies:
+  - entity_browser

--- a/src/Form/EntityEmbedDialog.php
+++ b/src/Form/EntityEmbedDialog.php
@@ -208,7 +208,7 @@ class EntityEmbedDialog extends FormBase {
       $this->eventDispatcher->addListener(Events::REGISTER_JS_CALLBACKS, [$this, 'registerJSCallback']);
 
       $form['attributes']['entity_browser']['#theme_wrappers'] = ['container'];
-      $form['attributes']['entity_browser']['browser'] = $this->entityBrowser->getDisplay()->displayEntityBrowser();
+      $form['attributes']['entity_browser']['browser'] = $this->entityBrowser->getDisplay()->displayEntityBrowser($form_state);
       $form['attributes']['entity_browser']['entity-id'] = [
         '#type' => 'hidden',
         '#default_value' => $entity ? $entity->id() : '',

--- a/src/Tests/EntityEmbedEntityBrowserTest.php
+++ b/src/Tests/EntityEmbedEntityBrowserTest.php
@@ -1,0 +1,71 @@
+<?php
+
+/**
+ * @file
+ * Contains \Drupal\entity_embed\Tests\EntityEmbedEntityBrowserTest.
+ */
+
+namespace Drupal\entity_embed\Tests;
+
+use Drupal\entity_browser\Entity\EntityBrowser;
+use Drupal\embed\Entity\EmbedButton;
+
+/**
+ * Tests the entity_embed entity_browser integration.
+ *
+ * @group entity_embed
+ * @dependencies entity_browser
+ */
+class EntityEmbedEntityBrowserTest extends EntityEmbedDialogTest {
+
+  /**
+   * Modules to enable.
+   *
+   * @var array
+   */
+  public static $modules = ['entity_browser'];
+
+  /**
+   * Tests the entity browser integration.
+   */
+  public function testEntityEmbedEntityBrowserIntegration() {
+    $this->getEmbedDialog('custom_format', 'node');
+    $this->assertResponse(200, 'Embed dialog is accessible with custom filter format and default embed button.');
+
+    // Verify that an autocomplete field is available by default.
+    $this->assertFieldByName('attributes[data-entity-id]', '', 'Entity ID/UUID field is present.');
+    $this->assertNoText('Select entities to embed', 'Entity browser button is not present.');
+
+    // Set up entity browser.
+    $entity_browser = EntityBrowser::create([
+      "name" => 'entity_embed_entity_browser_test',
+      "label" => 'Test Entity Browser for Entity Embed',
+      "display" => 'modal',
+      "display_configuration" => [
+        'width' => '650',
+        'height' => '500',
+        'link_text' => 'Select entities to embed',
+      ],
+      "selection_display" => 'no_display',
+      "selection_display_configuration" => [],
+      "widget_selector" => 'single',
+      "widget_selector_configuration" => [],
+      "widgets" => [],
+    ]);
+    $entity_browser->save();
+
+    // Enable entity browser for the default entity embed button.
+    $embed_button = EmbedButton::load('node');
+    $embed_button->type_settings['entity_browser'] = 'entity_embed_entity_browser_test';
+    $embed_button->save();
+
+    $this->getEmbedDialog('custom_format', 'node');
+    $this->assertResponse(200, 'Embed dialog is accessible with custom filter format and default embed button.');
+
+    // Verify that the autocomplete field is replaced by an entity browser
+    // button.
+    $this->assertNoFieldByName('attributes[data-entity-id]', '', 'Entity ID/UUID field is present.');
+    $this->assertText('Select entities to embed', 'Entity browser button is present.');
+  }
+
+}


### PR DESCRIPTION
With a fresh checkout of Entity Embed and Entity Browser, attempting to embed an entity using CKEditor fails with:

> Argument 1 passed to Drupal\entity_browser\Plugin\EntityBrowser\Display\Modal::displayEntityBrowser() must implement interface Drupal\Core\Form\FormStateInterface, none given, called in /entity_embed/src/Form/EntityEmbedDialog.php on line 211

It looks like Entity Browser's `displayEntityBrowser()` method must now be passed `$form_state`.
