### PR TITLE
Adding ajax_base_page to stop ajax errors on embed

### DIFF
--- a/entity_embed.routing.yml
+++ b/entity_embed.routing.yml
@@ -5,3 +5,5 @@ entity_embed.dialog:
     _title: 'Embed entity'
   requirements:
     _embed_button_editor_access: 'TRUE'
+  options:
+    _theme: ajax_base_page


### PR DESCRIPTION
Simple change which fixes the ajax errors when clicking an embed button
