### PR TITLE
Issue #2712111 by slashrsm, paranojik: Outdated cached version of embedded entity

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Entity Embed can be installed via the [standard Drupal installation process](htt
   * Enable the 'Display embedded entities' filter.
   * Drag and drop the 'E' button into the Active toolbar.
   * If the text format uses the 'Limit allowed HTML tags and correct faulty HTML' filter, ensure the necessary tags and attributes are whitelisted: add ```<drupal-entity data-entity-type data-entity-uuid data-entity-id data-view-mode data-entity-embed-display data-entity-embed-settings data-align data-caption data-embed-button>``` to the 'Allowed HTML tags' setting. (Will happen automatically after https://www.drupal.org/node/2554687.)
+  * If you're using both the 'Align images' and 'Caption images' filters make sure the 'Align images' filter is run before the 'Caption images' filter in the **Filter processing order** section. (Explanation: Due to the implementation details of the two filters it is important to execute them in the right sequence in order to obtain a sensible final markup. In practice this means that the alignment filter has to be run before the caption filter, otherwise the alignment class will appear inside the <figure> tag (instead of appearing on it) the caption filter produces.)
 
 ## Usage
 

--- a/src/EntityHelperTrait.php
+++ b/src/EntityHelperTrait.php
@@ -193,7 +193,11 @@ trait EntityHelperTrait {
 
     // Build and render the Entity Embed Display plugin, allowing modules to
     // alter the result before rendering.
-    $build = $this->renderEntityEmbedDisplayPlugin(
+    $build = array(
+      '#theme_wrappers' => ['container'],
+      '#attributes' => [],
+    );
+    $build['entity'] = $this->renderEntityEmbedDisplayPlugin(
       $entity,
       $context['data-entity-embed-display'],
       $context['data-entity-embed-settings'],
@@ -211,11 +215,6 @@ trait EntityHelperTrait {
     // Maintain data-caption if it is there.
     if (isset($context['data-caption'])) {
       $build['#attributes']['data-caption'] = $context['data-caption'];
-    }
-
-    // If this is an image, the image_formatter template expects #item_attributes.
-    if (!empty($build['#theme']) && !empty($build['#attributes']) && $build['#theme'] == 'image_formatter') {
-      $build['#item_attributes'] =  $build['#attributes'];
     }
 
     // @todo Should this hook get invoked if $build is an empty array?


### PR DESCRIPTION
Problem was that the data attributes were added to the embedded entity itself. This caused the same data attributes to appear everywhere the same view mode was used/displayed on the site. That also meant that the cached version was not invalidated until the embedded entity's cache was cleared.

To prevent all mentioned problems we wrap the embedded entity and append the data attributes to the wrapper element.
